### PR TITLE
ToYAMLStream helper

### DIFF
--- a/pkg/metahelm/yamlhelper.go
+++ b/pkg/metahelm/yamlhelper.go
@@ -1,0 +1,26 @@
+package metahelm
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/helm/pkg/strvals"
+)
+
+// ValueOverridesMap represents a set of chart YAML overrides, a map of YAML path to value,
+// in the same format as accepted by the helm CLI: "foo.bar=value" except in a map.
+type ValueOverridesMap map[string]string
+
+// ToYAMLStream takes overrides and serializes into a raw YAML stream that is assigned to c.ValueOverrides
+func (c *Chart) ToYAMLStream(overrides ValueOverridesMap) error {
+	sl := []string{}
+	for k, v := range overrides {
+		sl = append(sl, k+"="+v)
+	}
+	vo, err := strvals.ToYAML(strings.Join(sl, ","))
+	if err != nil {
+		return errors.Wrap(err, "error encoding values to YAML")
+	}
+	c.ValueOverrides = []byte(vo)
+	return nil
+}

--- a/pkg/metahelm/yamlhelper_test.go
+++ b/pkg/metahelm/yamlhelper_test.go
@@ -1,0 +1,44 @@
+package metahelm
+
+import (
+	"testing"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type testOverrides struct {
+	Image string `yaml:"image"`
+	Data  struct {
+		Foo int `yaml:"foo"`
+	} `yaml:"data"`
+}
+
+func TestYAMLHelperSingleLevel(t *testing.T) {
+	d := map[string]string{"image": "asdf"}
+	c := Chart{}
+	if err := c.ToYAMLStream(d); err != nil {
+		t.Fatalf("should have succeeded: %v", err)
+	}
+	ds := testOverrides{}
+	if err := yaml.Unmarshal(c.ValueOverrides, &ds); err != nil {
+		t.Fatalf("error unmarshaling: %v", err)
+	}
+	if ds.Image != d["image"] {
+		t.Fatalf("bad value: %v", ds.Image)
+	}
+}
+
+func TestYAMLHelperNestedLevel(t *testing.T) {
+	d := map[string]string{"data.foo": "1234"}
+	c := Chart{}
+	if err := c.ToYAMLStream(d); err != nil {
+		t.Fatalf("should have succeeded: %v", err)
+	}
+	ds := testOverrides{}
+	if err := yaml.Unmarshal(c.ValueOverrides, &ds); err != nil {
+		t.Fatalf("error unmarshaling: %v", err)
+	}
+	if ds.Data.Foo != 1234 {
+		t.Fatalf("bad value: %v", ds.Data.Foo)
+	}
+}


### PR DESCRIPTION
A small helper that serializes a map of YAML path to value overrides.