### PR TITLE
Do not abort on error getting deployment

### DIFF
--- a/pkg/metahelm/metahelm.go
+++ b/pkg/metahelm/metahelm.go
@@ -226,7 +226,7 @@ func (m *Manager) waitForChart(ctx context.Context, c *Chart, ns string) error {
 	return wait.Poll(ChartWaitPollInterval, c.WaitTimeout, func() (bool, error) {
 		d, err := m.K8c.ExtensionsV1beta1().Deployments(ns).Get(c.WaitUntilDeployment, metav1.GetOptions{})
 		if err != nil || d.Spec.Replicas == nil {
-			m.log("%v: error getting deployment (retrying)", c.Name())
+			m.log("%v: error getting deployment (retrying): %v", c.Name(), err)
 			return false, nil // the deployment may not initially exist immediately after installing chart
 		}
 

--- a/pkg/metahelm/metahelm.go
+++ b/pkg/metahelm/metahelm.go
@@ -226,7 +226,8 @@ func (m *Manager) waitForChart(ctx context.Context, c *Chart, ns string) error {
 	return wait.Poll(ChartWaitPollInterval, c.WaitTimeout, func() (bool, error) {
 		d, err := m.K8c.ExtensionsV1beta1().Deployments(ns).Get(c.WaitUntilDeployment, metav1.GetOptions{})
 		if err != nil || d.Spec.Replicas == nil {
-			return false, errors.Wrap(err, "error getting deployment")
+			m.log("%v: error getting deployment (retrying)", c.Name())
+			return false, nil // the deployment may not initially exist immediately after installing chart
 		}
 
 		rs, err := deploymentutil.GetNewReplicaSet(d, m.K8c.ExtensionsV1beta1())


### PR DESCRIPTION
Deployments may not exist yet immediately after doing a Helm install.