### PR TITLE
Optional chart validation for CLI

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -91,7 +91,7 @@ func validateChart(c ChartDefinition) error {
 	return nil
 }
 
-func readAndValidateFile(f string) ([]ChartDefinition, error) {
+func readAndValidateFile(f string, validate bool) ([]ChartDefinition, error) {
 	b, err := ioutil.ReadFile(f)
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading file")
@@ -103,9 +103,11 @@ func readAndValidateFile(f string) ([]ChartDefinition, error) {
 	if len(charts) == 0 {
 		return nil, errors.New("file is empty")
 	}
-	for i, c := range charts {
-		if err := validateChart(c); err != nil {
-			return nil, errors.Wrapf(err, "error validating chart at offset %v", i)
+	if validate {
+		for i, c := range charts {
+			if err := validateChart(c); err != nil {
+				return nil, errors.Wrapf(err, "error validating chart at offset %v", i)
+			}
 		}
 	}
 	return charts, nil
@@ -201,7 +203,7 @@ func install(cmd *cobra.Command, args []string) {
 		clierr("input file is required")
 	}
 	fp := args[len(args)-1]
-	cds, err := readAndValidateFile(fp)
+	cds, err := readAndValidateFile(fp, true)
 	if err != nil {
 		clierr("error reading input: %v", err)
 	}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -22,7 +22,7 @@ order with graph levels, and optionally a visual image of the graph.`,
 
 var opencmd = "<unknown>"
 var dotcmd string
-var genpng bool
+var genpng, validate bool
 
 func init() {
 	switch runtime.GOOS {
@@ -36,6 +36,7 @@ func init() {
 	planCmd.Flags().StringVar(&opencmd, "open-cmd", opencmd, "open CLI command")
 	planCmd.Flags().StringVar(&dotcmd, "dot-cmd", "dot", "dot CLI command (to generate PNG)")
 	planCmd.Flags().BoolVarP(&genpng, "gen-png", "g", false, "generate and display PNG graph")
+	planCmd.Flags().BoolVar(&validate, "validate", true, "validate charts")
 	RootCmd.AddCommand(planCmd)
 }
 
@@ -44,7 +45,7 @@ func plan(cmd *cobra.Command, args []string) {
 		clierr("input file is required")
 	}
 	fp := args[len(args)-1]
-	cds, err := readAndValidateFile(fp)
+	cds, err := readAndValidateFile(fp, validate)
 	if err != nil {
 		clierr("error reading input: %v", err)
 	}


### PR DESCRIPTION
If you just want to generate an example graph PNG, you don't care if the referenced charts actually exist on disk. This allows the user to disable chart validation with the CLI `plan` command.