### PR TITLE
Upgrade functionality implementation

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -42,10 +42,12 @@ type ChartDefinition struct {
 }
 
 type installCfg struct {
-	tillerNS      string
-	tillerTimeout time.Duration
-	k8sCtx        string
-	k8sNS         string
+	upgrade           bool
+	tillerNS          string
+	tillerTimeout     time.Duration
+	k8sCtx            string
+	k8sNS             string
+	releaseNamePrefix string
 }
 
 var instConfig installCfg
@@ -59,10 +61,12 @@ var installCmd = &cobra.Command{
 }
 
 func init() {
+	installCmd.Flags().BoolVar(&instConfig.upgrade, "upgrade", false, "Upgrade release if release exists")
 	installCmd.Flags().DurationVar(&instConfig.tillerTimeout, "tiller-timeout", 90*time.Second, "Tiller connect timeout")
 	installCmd.Flags().StringVar(&instConfig.tillerNS, "tiller-namespace", "kube-system", "k8s namespace where Tiller can be found")
 	installCmd.Flags().StringVar(&instConfig.k8sNS, "k8s-namespace", "", "k8s namespace into which to install charts")
 	installCmd.Flags().StringVar(&instConfig.k8sCtx, "k8s-ctx", "", "k8s context")
+	installCmd.Flags().StringVar(&instConfig.releaseNamePrefix, "release-name-prefix", "", "Release name prefix")
 	RootCmd.AddCommand(installCmd)
 }
 
@@ -245,7 +249,14 @@ func install(cmd *cobra.Command, args []string) {
 		K8c:  kc,
 		LogF: log.Printf,
 	}
-	rm, err := m.Install(context.Background(), cs, instConfig.ToInstallOptions()...)
+	var rm metahelm.ReleaseMap
+	if instConfig.upgrade {
+		rm = buildReleaseMap(instConfig, cs)
+		err = m.Upgrade(context.Background(), rm, cs, instConfig.ToInstallOptions()...)
+	} else {
+		rm, err = m.Install(context.Background(), cs, instConfig.ToInstallOptions()...)
+	}
+
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error running installations: %v\n", err)
 		return
@@ -253,6 +264,17 @@ func install(cmd *cobra.Command, args []string) {
 	for k, v := range rm {
 		fmt.Printf("Chart: %v => release: %v\n", k, v)
 	}
+}
+
+// buildReleaseMap build the release title to releaseName map using user input and charts definitions
+func buildReleaseMap(instConfig installCfg, cs []metahelm.Chart) metahelm.ReleaseMap {
+	rm := make(map[string]string)
+	for _, c := range cs {
+		if _, ok := rm[c.Title]; !ok {
+			rm[c.Title] = metahelm.ReleaseName(instConfig.releaseNamePrefix + c.Title)
+		}
+	}
+	return rm
 }
 
 func (instConfig *installCfg) ToInstallOptions() []metahelm.InstallOption {

--- a/pkg/metahelm/metahelm.go
+++ b/pkg/metahelm/metahelm.go
@@ -27,6 +27,7 @@ type K8sClient interface {
 type HelmClient interface {
 	InstallRelease(chstr, ns string, opts ...helm.InstallOption) (*rls.InstallReleaseResponse, error)
 	UpdateRelease(rlsName string, chstr string, opts ...helm.UpdateOption) (*rls.UpdateReleaseResponse, error)
+	ListReleases(opts ...helm.ReleaseListOption) (*rls.ListReleasesResponse, error)
 }
 
 // LogFunc is a function that logs a formatted string somewhere
@@ -127,7 +128,7 @@ func (m *Manager) Upgrade(ctx context.Context, rmap ReleaseMap, charts []Chart, 
 }
 
 // releaseName returns a release name of not more than 53 characters. If the input is truncated, a random number is added to ensure uniqueness.
-func releaseName(input string) string {
+func ReleaseName(input string) string {
 	rsl := []rune(input)
 	if len(rsl) < 54 {
 		return input
@@ -203,7 +204,15 @@ func (m *Manager) installOrUpgrade(ctx context.Context, upgradeMap ReleaseMap, u
 		}
 		c := cmap[obj.Name()]
 		var opstr string
+		var exist bool
 		if upgrade {
+			var err error
+			exist, err = releaseExists(m.HC, ops.k8sNamespace, ops.releaseNamePrefix+c.Title)
+			if err != nil {
+				return errors.Wrap(err, "error error getting release names")
+			}
+		}
+		if upgrade && exist {
 			relname, ok := upgradeMap[c.Title]
 			if !ok {
 				return fmt.Errorf("chart not found in release map: %v", c.Title)
@@ -233,7 +242,7 @@ func (m *Manager) installOrUpgrade(ctx context.Context, upgradeMap ReleaseMap, u
 			m.log("%v: running helm install", obj.Name())
 			resp, err := m.HC.InstallRelease(c.Location, ops.k8sNamespace,
 				helm.ValueOverrides(c.ValueOverrides),
-				helm.ReleaseName(releaseName(ops.releaseNamePrefix+c.Title)),
+				helm.ReleaseName(ReleaseName(ops.releaseNamePrefix+c.Title)),
 				helm.InstallWait(c.WaitUntilHelmSaysItsReady),
 				helm.InstallTimeout(int64(c.WaitTimeout.Seconds())))
 			if err != nil {
@@ -286,6 +295,15 @@ func (m *Manager) waitForChart(ctx context.Context, c *Chart, ns string) error {
 		}
 		return false, nil
 	})
+}
+
+func releaseExists(helmClient HelmClient, namespace string, releaseName string) (bool, error) {
+	releases, err := helmClient.ListReleases(helm.ReleaseListNamespace(namespace), helm.ReleaseListFilter("^"+releaseName+"$"))
+	if err != nil {
+		return false, errors.Wrap(err, "error getting release name")
+	}
+
+	return releases != nil && releases.Count == 1, nil
 }
 
 // ValidateCharts verifies that a set of charts is constructed properly, particularly with respect

--- a/pkg/metahelm/metahelm_test.go
+++ b/pkg/metahelm/metahelm_test.go
@@ -272,7 +272,7 @@ func TestReleaseName(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			out := releaseName(c.input)
+			out := ReleaseName(c.input)
 			if i := utf8.RuneCountInString(out); i > 53 {
 				t.Fatalf("length exceeds max of 53: %v", i)
 			}


### PR DESCRIPTION
This is an implementation of the "--upgrade" switch for the "install" command. Presence of this switch tells the "install" command to perform "upgrade" if service already exist. 

Metahelm is a great deployment tool for micro services with dependencies, however, without "upgrade" this tool is not really applicable in real life. Also "pure" upgrade (which fails if release exists) functionality may not be enough for many scenarios. In reality deployments are in various states such as fully "installed" and running, partially "installed" or "not installed" yet..... It would be good if this tool would have an "install or update" functionality.


 