### PR TITLE
Reset values on upgrade

### DIFF
--- a/pkg/metahelm/metahelm.go
+++ b/pkg/metahelm/metahelm.go
@@ -248,7 +248,8 @@ func (m *Manager) installOrUpgrade(ctx context.Context, upgradeMap ReleaseMap, u
 			}
 			opstr = "upgrade"
 			uops := []helm.UpdateOption{
-				helm.ResetValues(true),
+				// By not setting either ResetValues or ReuseValues, Helm will reuse the current release values
+				// only if no values are provided in the update request
 				helm.UpgradeWait(c.WaitUntilHelmSaysItsReady),
 				helm.UpgradeTimeout(int64(c.WaitTimeout.Seconds())),
 			}

--- a/pkg/metahelm/metahelm.go
+++ b/pkg/metahelm/metahelm.go
@@ -248,7 +248,7 @@ func (m *Manager) installOrUpgrade(ctx context.Context, upgradeMap ReleaseMap, u
 			}
 			opstr = "upgrade"
 			uops := []helm.UpdateOption{
-				helm.ReuseValues(true),
+				helm.ResetValues(true),
 				helm.UpgradeWait(c.WaitUntilHelmSaysItsReady),
 				helm.UpgradeTimeout(int64(c.WaitTimeout.Seconds())),
 			}


### PR DESCRIPTION
Fix a bug where changes to a chart's default values.yaml were not being reflected during chart upgrades.