### PR TITLE
chart errors: add test for ensuring we can marshal/unmarshal json

### DIFF
--- a/pkg/metahelm/error.go
+++ b/pkg/metahelm/error.go
@@ -29,8 +29,11 @@ type FailedPod struct {
 // ChartError is a chart install/upgrade error due to failing Kubernetes resources. It contains all Deployment, Job or DaemonSet-related pods that appear to
 // be in a failed state, including up to MaxPodLogLines of log data for each.
 type ChartError struct {
-	// HelmError is the original error string returned by Helm
-	HelmError string `json:"error"`
+	// HelmError is the original error returned by Helm
+	// We always omit this value when json marshaling/unmarshaling since we would otherwise have to implement the UnmarshalJSON and MarshalJSON methods.
+	HelmError error `json:"-"`
+	// HelmErrorString is the error string of the original error returned by Helm
+	HelmErrorString string `json:"error"`
 	// Level is the chart level (zero-indexed) at which the error occurred
 	Level uint `json:"level"`
 	// FailedDaemonSets is map of DaemonSet name to failed pods
@@ -44,7 +47,8 @@ type ChartError struct {
 // NewChartError returns an initialized empty ChartError
 func NewChartError(err error) ChartError {
 	return ChartError{
-		HelmError:         err.Error(),
+		HelmError:         err,
+		HelmErrorString:   err.Error(),
 		FailedDaemonSets:  make(map[string][]FailedPod),
 		FailedDeployments: make(map[string][]FailedPod),
 		FailedJobs:        make(map[string][]FailedPod),
@@ -53,7 +57,7 @@ func NewChartError(err error) ChartError {
 
 // Error satisfies the error interface
 func (ce ChartError) Error() string {
-	return errors.Wrap(fmt.Errorf("error executing level %v: failed resources (deployments: %v; jobs: %v; daemonsets: %v)", ce.Level, len(ce.FailedDeployments), len(ce.FailedJobs), len(ce.FailedDaemonSets)), ce.HelmError).Error()
+	return errors.Wrap(fmt.Errorf("error executing level %v: failed resources (deployments: %v; jobs: %v; daemonsets: %v)", ce.Level, len(ce.FailedDeployments), len(ce.FailedJobs), len(ce.FailedDaemonSets)), ce.HelmErrorString).Error()
 }
 
 // PopulateFromRelease finds the failed Jobs and Pods for a given release and fills ChartError with names and logs of the failed resources

--- a/pkg/metahelm/error.go
+++ b/pkg/metahelm/error.go
@@ -33,7 +33,7 @@ type ChartError struct {
 	// We always omit this value when json marshaling/unmarshaling since we would otherwise have to implement the UnmarshalJSON and MarshalJSON methods.
 	HelmError error `json:"-"`
 	// HelmErrorString is the error string of the original error returned by Helm
-	HelmErrorString string `json:"error"`
+	HelmErrorString string `json:"helm_error_string"`
 	// Level is the chart level (zero-indexed) at which the error occurred
 	Level uint `json:"level"`
 	// FailedDaemonSets is map of DaemonSet name to failed pods
@@ -46,9 +46,13 @@ type ChartError struct {
 
 // NewChartError returns an initialized empty ChartError
 func NewChartError(err error) ChartError {
+	errorString := ""
+	if err != nil {
+		errorString = err.Error()
+	}
 	return ChartError{
 		HelmError:         err,
-		HelmErrorString:   err.Error(),
+		HelmErrorString:   errorString,
 		FailedDaemonSets:  make(map[string][]FailedPod),
 		FailedDeployments: make(map[string][]FailedPod),
 		FailedJobs:        make(map[string][]FailedPod),

--- a/pkg/metahelm/error.go
+++ b/pkg/metahelm/error.go
@@ -30,7 +30,8 @@ type FailedPod struct {
 // be in a failed state, including up to MaxPodLogLines of log data for each.
 type ChartError struct {
 	// HelmError is the original error returned by Helm
-	HelmError error `json:"helm_error"`
+	// We always omit this value when json marshaling/unmarshaling since we would otherwise have to implement the UnmarshalJSON and MarshalJSON methods.
+	HelmError error `json:"-"`
 	// Level is the chart level (zero-indexed) at which the error occurred
 	Level uint `json:"level"`
 	// FailedDaemonSets is map of DaemonSet name to failed pods

--- a/pkg/metahelm/error.go
+++ b/pkg/metahelm/error.go
@@ -29,9 +29,8 @@ type FailedPod struct {
 // ChartError is a chart install/upgrade error due to failing Kubernetes resources. It contains all Deployment, Job or DaemonSet-related pods that appear to
 // be in a failed state, including up to MaxPodLogLines of log data for each.
 type ChartError struct {
-	// HelmError is the original error returned by Helm
-	// We always omit this value when json marshaling/unmarshaling since we would otherwise have to implement the UnmarshalJSON and MarshalJSON methods.
-	HelmError error `json:"-"`
+	// HelmError is the original error string returned by Helm
+	HelmError string `json:"error"`
 	// Level is the chart level (zero-indexed) at which the error occurred
 	Level uint `json:"level"`
 	// FailedDaemonSets is map of DaemonSet name to failed pods
@@ -45,7 +44,7 @@ type ChartError struct {
 // NewChartError returns an initialized empty ChartError
 func NewChartError(err error) ChartError {
 	return ChartError{
-		HelmError:         err,
+		HelmError:         err.Error(),
 		FailedDaemonSets:  make(map[string][]FailedPod),
 		FailedDeployments: make(map[string][]FailedPod),
 		FailedJobs:        make(map[string][]FailedPod),
@@ -54,7 +53,7 @@ func NewChartError(err error) ChartError {
 
 // Error satisfies the error interface
 func (ce ChartError) Error() string {
-	return errors.Wrap(fmt.Errorf("error executing level %v: failed resources (deployments: %v; jobs: %v; daemonsets: %v)", ce.Level, len(ce.FailedDeployments), len(ce.FailedJobs), len(ce.FailedDaemonSets)), ce.HelmError.Error()).Error()
+	return errors.Wrap(fmt.Errorf("error executing level %v: failed resources (deployments: %v; jobs: %v; daemonsets: %v)", ce.Level, len(ce.FailedDeployments), len(ce.FailedJobs), len(ce.FailedDaemonSets)), ce.HelmError).Error()
 }
 
 // PopulateFromRelease finds the failed Jobs and Pods for a given release and fills ChartError with names and logs of the failed resources

--- a/pkg/metahelm/error_test.go
+++ b/pkg/metahelm/error_test.go
@@ -273,7 +273,7 @@ func TestUnmarshalError(t *testing.T) {
 
 	encodedCE, err := json.Marshal(ce)
 	if err != nil {
-		t.Fatalf("unable to encode error")
+		t.Fatalf("unable to marshal error: %v", err)
 	}
 
 	var outputCE ChartError

--- a/pkg/metahelm/error_test.go
+++ b/pkg/metahelm/error_test.go
@@ -1,6 +1,7 @@
 package metahelm
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -200,5 +201,83 @@ func TestErrorPopulateFromDeployment(t *testing.T) {
 	}
 	if ec := fp[0].ContainerStatuses[0].State.Terminated.ExitCode; ec != 128 {
 		t.Fatalf("bad exit code: %v", ec)
+	}
+}
+
+func TestUnmarshalError(t *testing.T) {
+	r := &appsv1.ReplicaSet{}
+	d := &appsv1.Deployment{}
+	p := &corev1.Pod{}
+	p.ObjectMeta.Name = "foo-1234"
+	p.Namespace = DefaultK8sNamespace
+	p.ObjectMeta.Labels = map[string]string{"app": "foo"}
+	p.Status = corev1.PodStatus{
+		Phase: corev1.PodFailed,
+		Conditions: []corev1.PodCondition{
+			corev1.PodCondition{
+				Type:   corev1.PodScheduled,
+				Status: corev1.ConditionTrue,
+			},
+		},
+		ContainerStatuses: []corev1.ContainerStatus{
+			corev1.ContainerStatus{
+				Name: "foo",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 128,
+					},
+				},
+			},
+		},
+	}
+	reps := int32(1)
+	d.Spec.Replicas = &reps
+	d.Spec.Template.Labels = map[string]string{"app": "foo"}
+	d.Spec.Template.Spec.NodeSelector = map[string]string{}
+	d.Spec.Template.Name = "foo"
+	d.Spec.Selector = &metav1.LabelSelector{}
+	d.Spec.Selector.MatchLabels = map[string]string{"app": "foo"}
+	r.Spec.Selector = d.Spec.Selector
+	r.Spec.Replicas = &reps
+	r.Status.ReadyReplicas = 1
+	r.Name = "replicaset-" + "foo"
+	r.Namespace = DefaultK8sNamespace
+	r.Labels = d.Spec.Template.Labels
+	d.Labels = d.Spec.Template.Labels
+	d.ObjectMeta.UID = mtypes.UID("foo" + "-deployment")
+	iscontroller := true
+	r.ObjectMeta.OwnerReferences = []metav1.OwnerReference{metav1.OwnerReference{UID: d.ObjectMeta.UID, Controller: &iscontroller}}
+	d.Name = "foo"
+	d.ObjectMeta.Name = "foo"
+	d.Namespace = DefaultK8sNamespace
+	r.Spec.Template = d.Spec.Template
+	kc := fake.NewSimpleClientset(r, d, p)
+	ce := NewChartError(errors.New("some helm error"))
+	err := ce.PopulateFromDeployment(DefaultK8sNamespace, "foo", kc, 500)
+	if err != nil {
+		t.Fatalf("should have succeeded: %v", err)
+	}
+	if i := len(ce.FailedDeployments); i != 1 {
+		t.Fatalf("unexpected length for failed deployments: %v", i)
+	}
+	fp, ok := ce.FailedDeployments["foo"]
+	if !ok {
+		t.Fatalf("foo missing")
+	}
+	if i := len(fp); i != 1 {
+		t.Fatalf("unexpected length for failed pod: %v", i)
+	}
+	if ec := fp[0].ContainerStatuses[0].State.Terminated.ExitCode; ec != 128 {
+		t.Fatalf("bad exit code: %v", ec)
+	}
+
+	encodedCE, err := json.Marshal(ce)
+	if err != nil {
+		t.Fatalf("unable to encode error")
+	}
+
+	var outputCE ChartError
+	if err := json.Unmarshal(encodedCE, &outputCE); err != nil {
+		t.Fatalf("error unmarshaling chart error: %v", err)
 	}
 }

--- a/pkg/metahelm/error_test.go
+++ b/pkg/metahelm/error_test.go
@@ -255,20 +255,7 @@ func TestUnmarshalError(t *testing.T) {
 	ce := NewChartError(errors.New("some helm error"))
 	err := ce.PopulateFromDeployment(DefaultK8sNamespace, "foo", kc, 500)
 	if err != nil {
-		t.Fatalf("should have succeeded: %v", err)
-	}
-	if i := len(ce.FailedDeployments); i != 1 {
-		t.Fatalf("unexpected length for failed deployments: %v", i)
-	}
-	fp, ok := ce.FailedDeployments["foo"]
-	if !ok {
-		t.Fatalf("foo missing")
-	}
-	if i := len(fp); i != 1 {
-		t.Fatalf("unexpected length for failed pod: %v", i)
-	}
-	if ec := fp[0].ContainerStatuses[0].State.Terminated.ExitCode; ec != 128 {
-		t.Fatalf("bad exit code: %v", ec)
+		t.Fatalf("could not populate chart error from deployment: %v", err)
 	}
 
 	encodedCE, err := json.Marshal(ce)


### PR DESCRIPTION
Here is a go playground to shows a simple case of the errors we were running into when unmarshaling:
https://play.golang.org/p/Ued9Xy0TBPZ

The proposed fix is to always omit the error type in the Chart Error. While we lose a bit of information here, it's hard to really make any guarantees about the contents of the error since it's an interface type. 

We could potentially create our own MarshalJSON() / UnmarshalJSON() methods too if we prefer. However, this fix is a bit simpler and would still encode/decode the relevant information users would want to see (what pods failed and why).